### PR TITLE
change pg_dump to pg_basebackup

### DIFF
--- a/backup_general_jadi.sh
+++ b/backup_general_jadi.sh
@@ -47,7 +47,8 @@ fi
 
 # PSQL backups
 if [ $PSTGRBACKUP = 1 ];then
-nice /usr/bin/pg_dumpall -U${PSTGRDBUSER} | gzip -c > ${TMPDIR}/db/${HOSTNAME}_psql_backup-${DATESTAMP}-${DAYOFWEEK}.psql.gz
+nice pg_basebackup -D ./pg_current -c fast -X none -U "$PSTGRDBUSER"
+nice tar -czvf ${TMPDIR}/db/${HOSTNAME}_psql_backup-${DATESTAMP}-${DAYOFWEEK}.psql.tar.gz ./pg_current && rm -rf ./pg_current
 fi
 
 # Drush


### PR DESCRIPTION
with that we have lower TTR (Time to Recovery) and also it will not lock the database (by using PotgreSQL replication) also we could use master server and having more safe backups

also with that you can also get and archive WAL files to achieve PITR.